### PR TITLE
fix: update Babel configuration for core-js dependency

### DIFF
--- a/.babelrc.json
+++ b/.babelrc.json
@@ -6,8 +6,7 @@
     [
       "@babel/preset-env",
       {
-        "useBuiltIns": "usage",
-        "corejs": "3",
+        "useBuiltIns": "entry",
         "targets": [
             "> 0.25%, not dead",
             "node 8.6.0"


### PR DESCRIPTION
The Babel configuration in .babelrc.json has been updated. The "useBuiltIns" option was changed from "usage" to "entry". This change impacts how polyfills are included in the builds.