### PR TITLE
fix: update Node.js version and npm registry URL in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,8 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
 
       - uses: actions/cache@v4
         id: cache

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,7 +20,8 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
 
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -18,7 +18,8 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
 
       - uses: actions/cache@v4
         with:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "Francisco Ruiz",
   "repository": {
     "type": "git",
-    "url": "https://github.com/fdosruiz/packetjs.git"
+    "url": "git+https://github.com/fdosruiz/packetjs.git"
   },
   "engines": {
     "node": ">=8.6.0"


### PR DESCRIPTION
Changed the Node.js version to 20 in npm-publish, build, and semantic workflows. Additionally, specified the registry URL as https://registry.npmjs.org/ for these workflows. Also updated the repository URL in package.json.