### PR TITLE
feat: disable semantic release and npm publish in CI/CD pipeline

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,9 +1,9 @@
 name: CI/CD
 
 on:
-  pull_request:
-    branches:
-      - 'main'
+#  pull_request:
+#    branches:
+#      - 'main'
   push:
     branches:
       - 'main'

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,19 +7,20 @@ on:
   push:
     branches:
       - 'main'
+      - 'major/*'
 
 jobs:
   build:
     name: 'Stage #1'
     uses: ./.github/workflows/build.yml
 
-  qa:
-    needs: build
-    name: 'Stage #2'
-    uses: ./.github/workflows/qa.yml
+#  qa:
+#    needs: build
+#    name: 'Stage #2'
+#    uses: ./.github/workflows/qa.yml
 
   semantic:
-    needs: qa
+#    needs: qa
 #    if: github.event_name != 'pull_request'
     name: 'Stage #3'
     uses: ./.github/workflows/semantic.yml

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,9 +10,9 @@ on:
       - 'major/*'
 
 jobs:
-  build:
-    name: 'Stage #1'
-    uses: ./.github/workflows/build.yml
+#  build:
+#    name: 'Stage #1'
+#    uses: ./.github/workflows/build.yml
 
 #  qa:
 #    needs: build

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -20,13 +20,13 @@ jobs:
 
   semantic:
     needs: qa
-    if: github.event_name != 'pull_request'
+#    if: github.event_name != 'pull_request'
     name: 'Stage #3'
     uses: ./.github/workflows/semantic.yml
     secrets: inherit
 
-  npm-publish:
-    needs: semantic
-    name: 'Stage #4'
-    uses: ./.github/workflows/npm-publish.yml
-    secrets: inherit
+#  npm-publish:
+#    needs: semantic
+#    name: 'Stage #4'
+#    uses: ./.github/workflows/npm-publish.yml
+#    secrets: inherit

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,9 +10,9 @@ on:
       - 'major/*'
 
 jobs:
-#  build:
-#    name: 'Stage #1'
-#    uses: ./.github/workflows/build.yml
+  build:
+    name: 'Stage #1'
+    uses: ./.github/workflows/build.yml
 
 #  qa:
 #    needs: build
@@ -20,7 +20,7 @@ jobs:
 #    uses: ./.github/workflows/qa.yml
 
   semantic:
-#    needs: qa
+    needs: build
 #    if: github.event_name != 'pull_request'
     name: 'Stage #3'
     uses: ./.github/workflows/semantic.yml

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -28,11 +28,11 @@ jobs:
           restore-keys: |
             node_modules-
 
-#      - name: Download lib artifact
-#        uses: actions/download-artifact@v4
-#        with:
-#          name: lib-artifact
-#          path: lib
+      - name: Download lib artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: lib-artifact
+          path: lib
 
       - name: Create release and publish package
         env:

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -28,11 +28,11 @@ jobs:
           restore-keys: |
             node_modules-
 
-      - name: Download lib artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: lib-artifact
-          path: lib
+#      - name: Download lib artifact
+#        uses: actions/download-artifact@v4
+#        with:
+#          name: lib-artifact
+#          path: lib
 
       - name: Create release and publish package
         env:

--- a/.releaserc
+++ b/.releaserc
@@ -1,6 +1,6 @@
 {
   "branches": [
-    "main"
+    "main",
     "major/update-version"
   ],
   "plugins": [

--- a/.releaserc
+++ b/.releaserc
@@ -1,6 +1,7 @@
 {
   "branches": [
     "main"
+    "major/update-version"
   ],
   "plugins": [
     [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [2.0.0](https://github.com/fdosruiz/packetjs/compare/v1.4.0...v2.0.0) (2024-08-25)
+
+### ⚠ BREAKING CHANGES
+
+* Commented out the build stage in the CI/CD workflow and the lib artifact download step in the semantic workflow. This reduces unnecessary processing and aligns the workflows with current project requirements.
+* Added support for triggering CI/CD on branches prefixed with 'major/'. Additionally, commented out the QA stage and adjusted dependencies to ensure the build and semantic stages can run independently.
+* Commented out steps for semantic release and npm publish in the CI/CD workflow to prevent them from running. This change ensures that these stages are skipped, potentially to address issues or modify the release process.
+
+### Features
+
+* disable semantic release and npm publish in CI/CD pipeline ([c14eac7](https://github.com/fdosruiz/packetjs/commit/c14eac7ef368c39365a17b334114e9719fc394f5))
+* disable unused steps in CI/CD and semantic workflows ([9b1c8fb](https://github.com/fdosruiz/packetjs/commit/9b1c8fba9bffbead95b5a097f9b876fe998ca743))
+* enable CI/CD for major branches and comment out QA stage ([0829b05](https://github.com/fdosruiz/packetjs/commit/0829b0551bf437ff1a934588c102e67d94d2c9ab))
+
 ## [1.4.0](https://github.com/fdosruiz/packetjs/compare/v1.3.4...v1.4.0) (2024-08-25)
 
 ### Major Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "packetjs-di",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "packetjs-di",
-      "version": "1.4.0",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.18.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "packetjs-di",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "Packet.js DI, a lightweight and powerful Dependency Injection container, written in TypeScript and made for JavaScript applications like Node.js, Angular, React, Vue, Vanilla JS, TypeScript, etc., and for efficient management of dependencies, with features like lazy loading, middleware management, and caching.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
BREAKING CHANGE: Commented out steps for semantic release and npm publish in the CI/CD workflow to prevent them from running. This change ensures that these stages are skipped, potentially to address issues or modify the release process.